### PR TITLE
Fix bug causing false positives for PLU002

### DIFF
--- a/flake8_plus/visitors/base_visitor.py
+++ b/flake8_plus/visitors/base_visitor.py
@@ -1,5 +1,6 @@
 """Base class for visitors used in Flake8-plus."""
 import ast
+from typing import Any
 
 from ..config import Config
 from ..exceptions import MultipleStatementsError
@@ -20,6 +21,21 @@ class BaseVisitor(ast.NodeVisitor):
         self.problems: list[Problem] = []
         self._lines = lines
         self.config = config
+        self._previous_node = None
+
+    def visit(self, node: ast.AST) -> Any:
+        """
+        Visit an `AST` instance.
+
+        Args:
+            node (ast.AST): The abstract syntax tree to visit.
+
+        Returns:
+            Any: The result of calling `visit` on the super class.
+        """
+        result = super().visit(node)
+        self._previous_node = node
+        return result
 
     def compute_blanks_before(self, node: ast.AST) -> int:
         """

--- a/flake8_plus/visitors/plu002_visitor.py
+++ b/flake8_plus/visitors/plu002_visitor.py
@@ -49,16 +49,21 @@ class PLU002Visitor(BaseVisitor):
             Any: The result of calling `generic_visit`.
         """
         # pylint: disable=invalid-name
+        if not isinstance(self._previous_node, ast.FunctionDef | ast.ClassDef):
+            self._process_node(node)
+        return self.generic_visit(node)
+
+    def _process_node(self, node: ast.Return):
         try:
             actual = self.compute_blanks_before(node)
-            if actual != self.config.blanks_before_return:
-                problem = PLU002Problem(
-                    node.lineno,
-                    node.col_offset,
-                    actual,
-                    self.config.blanks_before_return,
-                )
-                self.problems.append(problem)
         except MultipleStatementsError:
-            pass
-        return self.generic_visit(node)
+            return
+
+        if actual != self.config.blanks_before_return:
+            problem = PLU002Problem(
+                node.lineno,
+                node.col_offset,
+                actual,
+                self.config.blanks_before_return,
+            )
+            self.problems.append(problem)

--- a/tests/case_files/plu002/cases.json
+++ b/tests/case_files/plu002/cases.json
@@ -13,6 +13,32 @@
     ]
   },
   {
+    "filename": "inner_class.py",
+    "cases": [
+      {
+        "expectation": { "blanks_expected": 0 },
+        "problems": []
+      },
+      {
+        "expectation": { "blanks_expected": 1 },
+        "problems": []
+      }
+    ]
+  },
+  {
+    "filename": "inner_function.py",
+    "cases": [
+      {
+        "expectation": { "blanks_expected": 0 },
+        "problems": []
+      },
+      {
+        "expectation": { "blanks_expected": 1 },
+        "problems": [{ "line_number": 7, "col_offset": 12, "blanks_actual": 0 }]
+      }
+    ]
+  },
+  {
     "filename": "no_blanks.py",
     "cases": [
       {

--- a/tests/case_files/plu002/inner_class.py
+++ b/tests/case_files/plu002/inner_class.py
@@ -1,0 +1,6 @@
+class SomeClass:
+    def some_func(self) -> type:
+        class SomeInnerClass:
+            pass
+
+        return SomeInnerClass

--- a/tests/case_files/plu002/inner_function.py
+++ b/tests/case_files/plu002/inner_function.py
@@ -1,0 +1,9 @@
+from typing import Callable
+
+
+class SomeClass:
+    def some_func(self) -> Callable[..., int]:
+        def inner_func() -> int:
+            return 27
+
+        return inner_func


### PR DESCRIPTION
When an inner class or function was immediately followed by a `return`, false positives could occur because other linters and formatters may require a specific number of blanks after classes and functions. One example is Black. Thus, this pull request improves the compatibility with Black.