### PR TITLE
Fix bug causing false positives for PLU002

### DIFF
--- a/flake8_plus/visitors/plu002_visitor.py
+++ b/flake8_plus/visitors/plu002_visitor.py
@@ -49,7 +49,9 @@ class PLU002Visitor(BaseVisitor):
             Any: The result of calling `generic_visit`.
         """
         # pylint: disable=invalid-name
-        if not isinstance(self._previous_node, ast.FunctionDef | ast.ClassDef):
+        if not isinstance(
+            self._previous_node, ast.AsyncFunctionDef | ast.ClassDef | ast.FunctionDef
+        ):
             self._process_node(node)
         return self.generic_visit(node)
 

--- a/tests/case_files/plu002/cases.json
+++ b/tests/case_files/plu002/cases.json
@@ -26,6 +26,19 @@
     ]
   },
   {
+    "filename": "inner_coroutine.py",
+    "cases": [
+      {
+        "expectation": { "blanks_expected": 0 },
+        "problems": []
+      },
+      {
+        "expectation": { "blanks_expected": 1 },
+        "problems": [{ "line_number": 6, "col_offset": 8, "blanks_actual": 0 }]
+      }
+    ]
+  },
+  {
     "filename": "inner_function.py",
     "cases": [
       {

--- a/tests/case_files/plu002/inner_coroutine.py
+++ b/tests/case_files/plu002/inner_coroutine.py
@@ -1,0 +1,8 @@
+from typing import Any, Callable, Coroutine
+
+
+def some_func() -> Callable[..., Coroutine[Any, Any, int]]:
+    async def inner_func() -> int:
+        return 27
+
+    return inner_func


### PR DESCRIPTION
When an inner async function was immediately followed by a `return`, false positives could occur because other linters and formatters may require a specific number of blanks after classes and functions. One example is Black.